### PR TITLE
Add OAuth2 authorization_code flow, ticketing, scripts, and docs APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,59 @@ NINJA_BASE_URL=https://app.ninjarmm.com
 # NINJA_REGION=eu
 # Optional: override auto-detect candidates
 # NINJA_BASE_URLS=https://app.ninjarmm.com,https://eu.ninjarmm.com
+
+# Auth mode: client_credentials (default) or authorization_code
+# NINJA_AUTH_MODE=authorization_code
+# NINJA_OAUTH_REDIRECT_URI=http://localhost:8765/callback
+# NINJA_OAUTH_PORT=8765
+# NINJA_OAUTH_SCOPES=monitoring management control offline_access
+# NINJA_TOKEN_DIR=
+
 MCP_MODE=stdio
 HTTP_PORT=3000
 SSE_PORT=3001
 ```
+
+## Authentication
+
+Two OAuth2 flows are supported and can be switched via `NINJA_AUTH_MODE`:
+
+### 1. Client Credentials (default)
+Service-to-service. Works for most read/write operations (devices, orgs, alerts,
+tickets, documentation, webhooks, custom fields, etc.).
+
+```env
+NINJA_AUTH_MODE=client_credentials
+NINJA_CLIENT_ID=...
+NINJA_CLIENT_SECRET=...
+```
+
+### 2. Authorization Code (web auth)
+User-context flow with browser login and refresh tokens. **Required** for
+endpoints that must run in a user context, most notably running scripts on
+devices (`run_device_script`).
+
+1. In NinjaOne admin → **Apps → API → Client App IDs**, register your app with
+   **authorization_code** grant enabled and add a redirect URI that matches
+   `NINJA_OAUTH_REDIRECT_URI` (default `http://localhost:8765/callback`).
+2. Set:
+   ```env
+   NINJA_AUTH_MODE=authorization_code
+   NINJA_CLIENT_ID=...
+   # NINJA_CLIENT_SECRET only needed for confidential clients
+   NINJA_OAUTH_SCOPES=monitoring management control offline_access
+   ```
+3. From the MCP client, call the `ninja_auth_login` tool. The MCP will:
+   - Open your browser to the NinjaOne authorize URL.
+   - Listen on the loopback port for the callback with PKCE verification.
+   - Store the refresh token under `~/.ninjaone-mcp/tokens.json` (mode `0600`).
+4. If the loopback cannot receive the callback (e.g. headless server, blocked
+   port), call `ninja_auth_login` with `{ "manual": true }` and paste the full
+   redirect URL into `ninja_auth_paste_redirect`.
+5. Use `ninja_auth_status` to inspect token state and `ninja_auth_logout` to
+   clear stored tokens.
+
+PKCE (S256) is always enabled — no additional configuration required.
 
 ### Build and Run
 
@@ -221,8 +270,10 @@ The NinjaOne Public API has the following known limitations:
 - **Update Phone**: The phone field can be set during creation but cannot be updated afterwards
 
 ### Other Restrictions
-- **Script Execution**: Running scripts requires authorization code flow, not supported with client credentials
-- All other CRUD operations work as expected
+- **Script Execution**: Running scripts (`run_device_script`) requires the
+  `authorization_code` flow. Set `NINJA_AUTH_MODE=authorization_code` and run
+  `ninja_auth_login`. See the **Authentication** section above.
+- All other CRUD operations work with either flow.
 
 ## MCP Integration
 
@@ -264,9 +315,21 @@ Build first so `dist/index.js` exists: `npm install && npm run build`. Then rest
 
 ### Available Tools
 
-The server provides 29+ tools covering all major NinjaONE operations:
+The server provides 55+ tools covering all major NinjaONE operations:
 
-**Device Tools**: `get_devices`, `get_device`, `reboot_device`, `get_device_activities`, `get_device_software`, `search_devices_by_name`, `find_windows11_devices`
+**Auth Tools** (for `authorization_code` flow): `ninja_auth_status`, `ninja_auth_login`, `ninja_auth_paste_redirect`, `ninja_auth_logout`
+
+**Device Tools**: `get_devices`, `get_device`, `reboot_device`, `get_device_activities`, `get_device_software`, `search_devices_by_name`, `find_windows11_devices`, `get_device_custom_fields`, `update_device_custom_fields`
+
+**Ticketing Tools**: `get_tickets`, `get_ticket`, `create_ticket`, `update_ticket`, `get_ticket_log_entries`, `add_ticket_log_entry`, `get_ticketing_attributes`, `get_ticketing_contacts`
+
+**Script Tools** (requires authorization_code): `get_device_scripting_options`, `run_device_script`, `get_job_status`
+
+**Documentation Tools**: `get_document_templates`, `get_document_template`, `create_document_template`, `update_document_template`, `get_organization_documents`, `create_organization_document`, `update_organization_document`
+
+**Webhook Tools**: `set_webhook`, `delete_webhook`
+
+**Attachment Tools**: `get_attachment`
 
 #### Device Software Inventory Tool
 
@@ -285,7 +348,7 @@ The server provides 29+ tools covering all major NinjaONE operations:
 
 **Custom Fields & Policy Query Tools**: `query_custom_fields`, `query_custom_fields_detailed`, `query_scoped_custom_fields`, `query_scoped_custom_fields_detailed`, `query_policy_overrides`
 
-**Backup Query Tools**: `query_backup_usage`
+**Backup Query Tools**: `query_backup_usage`, `query_backup_jobs`, `query_backup_integrity`
 
 ## Region and Base URL
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -130,6 +130,49 @@ When running through Claude Desktop or other MCP clients:
 4. ❌ Forgetting to restart Claude after config changes
 5. ❌ Missing quotes around string values in JSON config
 
+## Authorization Code (browser login) flow
+
+Use this flow when you need endpoints that must run in a user context
+(most notably `run_device_script`).
+
+1. In NinjaOne admin (**Apps → API → Client App IDs**), either register a new
+   application with **Authorization Code** grant enabled or enable it on an
+   existing application.
+2. Add a **redirect URI** that matches your MCP config. The default is
+   `http://localhost:8765/callback` — if the port is in use, pick another and
+   set both `NINJA_OAUTH_PORT` and `NINJA_OAUTH_REDIRECT_URI` accordingly.
+3. Configure the MCP client with the new env vars:
+   ```json
+   {
+     "mcpServers": {
+       "ninjaone": {
+         "command": "node",
+         "args": ["/path/to/NinjaOneMCP/dist/index.js"],
+         "env": {
+           "NINJA_AUTH_MODE": "authorization_code",
+           "NINJA_CLIENT_ID": "<client_id>",
+           "NINJA_CLIENT_SECRET": "<client_secret_if_confidential>",
+           "NINJA_BASE_URL": "https://app.ninjarmm.com",
+           "NINJA_OAUTH_REDIRECT_URI": "http://localhost:8765/callback",
+           "NINJA_OAUTH_PORT": "8765",
+           "NINJA_OAUTH_SCOPES": "monitoring management control offline_access",
+           "MCP_MODE": "stdio"
+         }
+       }
+     }
+   }
+   ```
+4. Restart the MCP client.
+5. In a chat, invoke the `ninja_auth_login` tool. Your browser opens, you sign
+   in, and the MCP captures the code via the loopback callback. Tokens are
+   written to `~/.ninjaone-mcp/tokens.json` with `0600` permissions. Set
+   `NINJA_TOKEN_DIR` to override this path.
+6. Headless / blocked port: call `ninja_auth_login` with `{ "manual": true }`,
+   open the returned `authorizeUrl` in any browser, then paste the full
+   redirected URL into `ninja_auth_paste_redirect`.
+7. `ninja_auth_status` reports mode, token expiry, and whether a refresh token
+   is stored. `ninja_auth_logout` clears the token file.
+
 ## Testing Your Setup
 
 ### Test Local Setup

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -382,6 +382,47 @@ The current implementation includes core tools. A full implementation would incl
 
 And many more covering all aspects of the NinjaONE platform.
 
+### Authentication (authorization_code flow)
+- `ninja_auth_status` — show auth mode, token expiry, refresh-token state.
+- `ninja_auth_login` — start browser login; returns `authorizeUrl`. Pass
+  `{ "manual": true }` to skip loopback and only return the URL.
+- `ninja_auth_paste_redirect` — complete login by pasting the full redirect
+  URL (contains `?code=...&state=...`). Required for headless/manual flows.
+- `ninja_auth_logout` — clear stored tokens (`~/.ninjaone-mcp/tokens.json`).
+
+### Ticketing
+- `get_tickets` — filter/paginate tickets.
+- `get_ticket`, `create_ticket`, `update_ticket`.
+- `get_ticket_log_entries`, `add_ticket_log_entry` — comments & activity.
+- `get_ticketing_attributes` — statuses/priorities/custom-field metadata.
+- `get_ticketing_contacts` — ticket contact directory.
+
+### Scripts (require `NINJA_AUTH_MODE=authorization_code`)
+- `get_device_scripting_options` — scripts/actions available on a device.
+- `run_device_script` — execute a script; payload follows NinjaOne spec
+  (`{ type, uid|id, parameters?, runAs? }`).
+- `get_job_status` — poll a job by UID.
+
+### NinjaOne Documentation
+- `get_document_templates`, `get_document_template`.
+- `create_document_template`, `update_document_template`.
+- `get_organization_documents`, `create_organization_document`,
+  `update_organization_document`.
+
+### Device Custom Fields
+- `get_device_custom_fields`, `update_device_custom_fields` (object of
+  `{ fieldName: value }`).
+
+### Webhooks
+- `set_webhook` (PUT), `delete_webhook`.
+
+### Attachments
+- `get_attachment` — returns `{ contentType, base64, size }`.
+
+### Backup (additions)
+- `query_backup_jobs`, `query_backup_integrity` — in addition to the existing
+  `query_backup_usage`.
+
 ## Support and Documentation
 
 For detailed API documentation, refer to:

--- a/manifest.json
+++ b/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": "0.2",
   "name": "ninjaone-rmm",
   "display_name": "NinjaONE RMM Server",
-  "version": "1.2.14",
-  "description": "Professional MCP server for NinjaONE RMM platform with comprehensive device management, monitoring, patch management, and automation capabilities",
+  "version": "1.3.0",
+  "description": "Professional MCP server for NinjaONE RMM platform with comprehensive device management, ticketing, documentation, monitoring, patch management, script execution, and automation capabilities",
   "author": {
     "name": "Lungshot",
     "email": "support@ninjaone-mcp.dev",
@@ -27,6 +27,11 @@
         "NINJA_BASE_URL": "${user_config.base_url}",
         "NINJA_CLIENT_ID": "${user_config.client_id}",
         "NINJA_CLIENT_SECRET": "${user_config.client_secret}",
+        "NINJA_AUTH_MODE": "${user_config.auth_mode}",
+        "NINJA_OAUTH_REDIRECT_URI": "${user_config.redirect_uri}",
+        "NINJA_OAUTH_PORT": "${user_config.oauth_port}",
+        "NINJA_OAUTH_SCOPES": "${user_config.scopes}",
+        "NINJA_TOKEN_DIR": "${user_config.token_dir}",
         "LOG_LEVEL": "${user_config.log_level}",
         "NODE_ENV": "production"
       }
@@ -39,6 +44,12 @@
       "description": "Your NinjaONE regional API endpoint (e.g., https://app.ninjarmm.com, https://eu.ninjarmm.com)",
       "default": "https://app.ninjarmm.com"
     },
+    "auth_mode": {
+      "type": "string",
+      "title": "Auth Mode",
+      "description": "OAuth2 flow to use. 'client_credentials' is the default (service-to-service). 'authorization_code' enables browser login and is REQUIRED for running scripts.",
+      "default": "client_credentials"
+    },
     "client_id": {
       "type": "string",
       "title": "OAuth Client ID",
@@ -47,8 +58,32 @@
     "client_secret": {
       "type": "string",
       "title": "OAuth Client Secret",
-      "description": "Your NinjaONE OAuth2 application client secret",
+      "description": "Your NinjaONE OAuth2 application client secret. Required for client_credentials; optional for authorization_code with PKCE (public clients).",
       "sensitive": true
+    },
+    "redirect_uri": {
+      "type": "string",
+      "title": "OAuth Redirect URI",
+      "description": "Redirect URI registered in your NinjaONE OAuth app (authorization_code flow). Must match exactly. Default uses loopback.",
+      "default": "http://localhost:8765/callback"
+    },
+    "oauth_port": {
+      "type": "string",
+      "title": "OAuth Loopback Port",
+      "description": "Local TCP port used by the loopback callback server during authorization_code login.",
+      "default": "8765"
+    },
+    "scopes": {
+      "type": "string",
+      "title": "OAuth Scopes",
+      "description": "Space-separated scopes. For authorization_code include 'offline_access' to receive a refresh token.",
+      "default": "monitoring management control offline_access"
+    },
+    "token_dir": {
+      "type": "string",
+      "title": "Token Storage Directory",
+      "description": "Directory where refresh/access tokens are persisted (permissions 0600). Defaults to ~/.ninjaone-mcp.",
+      "default": ""
     },
     "log_level": {
       "type": "string",

--- a/mcp-config.json.example
+++ b/mcp-config.json.example
@@ -14,6 +14,13 @@
         "NINJA_CLIENT_ID": "<your_client_id>",
         "NINJA_CLIENT_SECRET": "<your_client_secret>",
         "NINJA_BASE_URL": "https://eu.ninjarmm.com",
+
+        "// Auth": "Use client_credentials (default) or authorization_code for web-auth / scripts",
+        "NINJA_AUTH_MODE": "client_credentials",
+        "NINJA_OAUTH_REDIRECT_URI": "http://localhost:8765/callback",
+        "NINJA_OAUTH_PORT": "8765",
+        "NINJA_OAUTH_SCOPES": "monitoring management control offline_access",
+
         "MCP_MODE": "stdio",
         "HTTP_PORT": "3000",
         "SSE_PORT": "3001",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ninjaone-mcp-server",
-  "version": "1.2.13",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ninjaone-mcp-server",
-      "version": "1.2.13",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.1",
@@ -800,7 +800,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -1668,7 +1667,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
       "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ninjaone-mcp-server",
-  "version": "1.2.13",
+  "version": "1.3.0",
   "description": "Modern MCP server for NinjaONE RMM platform with HTTP/SSE support",
   "main": "dist/index.js",
   "type": "module",

--- a/src/auth/authorization-code.ts
+++ b/src/auth/authorization-code.ts
@@ -1,0 +1,121 @@
+import * as crypto from 'crypto';
+
+export interface TokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  token_type?: string;
+  scope?: string;
+}
+
+export interface PkcePair {
+  verifier: string;
+  challenge: string;
+  method: 'S256';
+}
+
+function base64UrlEncode(buf: Buffer): string {
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export function createPkcePair(): PkcePair {
+  const verifier = base64UrlEncode(crypto.randomBytes(32));
+  const challenge = base64UrlEncode(crypto.createHash('sha256').update(verifier).digest());
+  return { verifier, challenge, method: 'S256' };
+}
+
+export function createState(): string {
+  return base64UrlEncode(crypto.randomBytes(16));
+}
+
+export interface AuthorizeUrlParams {
+  baseUrl: string;
+  clientId: string;
+  redirectUri: string;
+  scope: string;
+  state: string;
+  codeChallenge: string;
+}
+
+export function buildAuthorizeUrl(params: AuthorizeUrlParams): string {
+  const search = new URLSearchParams({
+    response_type: 'code',
+    client_id: params.clientId,
+    redirect_uri: params.redirectUri,
+    scope: params.scope,
+    state: params.state,
+    code_challenge: params.codeChallenge,
+    code_challenge_method: 'S256',
+  });
+  return `${params.baseUrl.replace(/\/+$/, '')}/ws/oauth/authorize?${search.toString()}`;
+}
+
+export interface ExchangeCodeParams {
+  baseUrl: string;
+  code: string;
+  codeVerifier: string;
+  redirectUri: string;
+  clientId: string;
+  clientSecret?: string;
+}
+
+export async function exchangeCode(p: ExchangeCodeParams): Promise<TokenResponse> {
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code: p.code,
+    redirect_uri: p.redirectUri,
+    client_id: p.clientId,
+    code_verifier: p.codeVerifier,
+  });
+  if (p.clientSecret) body.append('client_secret', p.clientSecret);
+  return postToken(p.baseUrl, body);
+}
+
+export interface RefreshParams {
+  baseUrl: string;
+  refreshToken: string;
+  clientId: string;
+  clientSecret?: string;
+  scope?: string;
+}
+
+export async function refresh(p: RefreshParams): Promise<TokenResponse> {
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: p.refreshToken,
+    client_id: p.clientId,
+  });
+  if (p.clientSecret) body.append('client_secret', p.clientSecret);
+  if (p.scope) body.append('scope', p.scope);
+  return postToken(p.baseUrl, body);
+}
+
+async function postToken(baseUrl: string, body: URLSearchParams): Promise<TokenResponse> {
+  const url = `${baseUrl.replace(/\/+$/, '')}/ws/oauth/token`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Accept': 'application/json',
+    },
+    body: body.toString(),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`OAuth token request failed: ${response.status} ${response.statusText} - ${text}`);
+  }
+  return (await response.json()) as TokenResponse;
+}
+
+export function parseRedirectUrl(url: string): { code: string | null; state: string | null; error: string | null } {
+  try {
+    const parsed = new URL(url);
+    return {
+      code: parsed.searchParams.get('code'),
+      state: parsed.searchParams.get('state'),
+      error: parsed.searchParams.get('error'),
+    };
+  } catch {
+    return { code: null, state: null, error: 'invalid_url' };
+  }
+}

--- a/src/auth/loopback.ts
+++ b/src/auth/loopback.ts
@@ -1,0 +1,106 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'http';
+import { spawn } from 'child_process';
+import { URL } from 'url';
+
+export interface LoopbackResult {
+  code: string;
+  state: string;
+}
+
+export interface LoopbackOptions {
+  redirectUri: string;
+  expectedState: string;
+  timeoutMs?: number;
+}
+
+const SUCCESS_HTML = `<!doctype html><html><head><meta charset="utf-8"><title>NinjaOne MCP</title></head><body style="font-family:sans-serif;padding:2rem"><h2>Login complete</h2><p>You can close this tab and return to the MCP client.</p></body></html>`;
+const ERROR_HTML = (msg: string) =>
+  `<!doctype html><html><head><meta charset="utf-8"><title>NinjaOne MCP</title></head><body style="font-family:sans-serif;padding:2rem"><h2>Login failed</h2><p>${msg}</p></body></html>`;
+
+export async function waitForCallback(opts: LoopbackOptions): Promise<LoopbackResult> {
+  const parsedRedirect = new URL(opts.redirectUri);
+  const host = parsedRedirect.hostname || '127.0.0.1';
+  const port = parsedRedirect.port ? Number(parsedRedirect.port) : 8765;
+  const pathname = parsedRedirect.pathname || '/callback';
+  const timeout = opts.timeoutMs ?? 120_000;
+
+  return new Promise<LoopbackResult>((resolve, reject) => {
+    let settled = false;
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      try {
+        if (!req.url) {
+          res.statusCode = 400;
+          res.end();
+          return;
+        }
+        const reqUrl = new URL(req.url, `http://${host}:${port}`);
+        if (reqUrl.pathname !== pathname) {
+          res.statusCode = 404;
+          res.end();
+          return;
+        }
+        const code = reqUrl.searchParams.get('code');
+        const state = reqUrl.searchParams.get('state');
+        const error = reqUrl.searchParams.get('error');
+        if (error) {
+          res.statusCode = 400;
+          res.setHeader('Content-Type', 'text/html; charset=utf-8');
+          res.end(ERROR_HTML(`OAuth error: ${error}`));
+          finish(new Error(`OAuth error: ${error}`));
+          return;
+        }
+        if (!code || !state) {
+          res.statusCode = 400;
+          res.setHeader('Content-Type', 'text/html; charset=utf-8');
+          res.end(ERROR_HTML('Missing code/state in callback.'));
+          finish(new Error('Missing code/state in callback'));
+          return;
+        }
+        if (state !== opts.expectedState) {
+          res.statusCode = 400;
+          res.setHeader('Content-Type', 'text/html; charset=utf-8');
+          res.end(ERROR_HTML('State mismatch — possible CSRF.'));
+          finish(new Error('State mismatch'));
+          return;
+        }
+        res.statusCode = 200;
+        res.setHeader('Content-Type', 'text/html; charset=utf-8');
+        res.end(SUCCESS_HTML);
+        finish(null, { code, state });
+      } catch (err) {
+        finish(err as Error);
+      }
+    });
+
+    const timer = setTimeout(() => {
+      finish(new Error(`Loopback callback timed out after ${timeout}ms`));
+    }, timeout);
+
+    function finish(err: Error | null, result?: LoopbackResult) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      server.close();
+      if (err || !result) reject(err ?? new Error('unknown loopback failure'));
+      else resolve(result);
+    }
+
+    server.on('error', (err: Error) => finish(err));
+    server.listen(port, host);
+  });
+}
+
+export function openBrowser(url: string): void {
+  const platform = process.platform;
+  try {
+    if (platform === 'darwin') {
+      spawn('open', [url], { detached: true, stdio: 'ignore' }).unref();
+    } else if (platform === 'win32') {
+      spawn('cmd', ['/c', 'start', '""', url], { detached: true, stdio: 'ignore' }).unref();
+    } else {
+      spawn('xdg-open', [url], { detached: true, stdio: 'ignore' }).unref();
+    }
+  } catch {
+    // Best effort. Caller will still display the URL.
+  }
+}

--- a/src/auth/token-store.ts
+++ b/src/auth/token-store.ts
@@ -1,0 +1,75 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+export interface StoredTokens {
+  refreshToken: string | null;
+  accessToken: string | null;
+  expiresAt: number | null;
+  tenantBaseUrl: string | null;
+  scope: string | null;
+  clientId: string | null;
+}
+
+const FILE_NAME = 'tokens.json';
+
+function resolveDir(): string {
+  const override = process.env.NINJA_TOKEN_DIR;
+  if (override && override.trim().length > 0) {
+    return override;
+  }
+  return path.join(os.homedir(), '.ninjaone-mcp');
+}
+
+function resolvePath(): string {
+  return path.join(resolveDir(), FILE_NAME);
+}
+
+export async function load(): Promise<StoredTokens | null> {
+  const file = resolvePath();
+  try {
+    const raw = await fs.readFile(file, 'utf8');
+    const parsed = JSON.parse(raw) as Partial<StoredTokens>;
+    return {
+      refreshToken: parsed.refreshToken ?? null,
+      accessToken: parsed.accessToken ?? null,
+      expiresAt: typeof parsed.expiresAt === 'number' ? parsed.expiresAt : null,
+      tenantBaseUrl: parsed.tenantBaseUrl ?? null,
+      scope: parsed.scope ?? null,
+      clientId: parsed.clientId ?? null,
+    };
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === 'ENOENT') return null;
+    console.error('[token-store] failed to read token file:', err);
+    return null;
+  }
+}
+
+export async function save(tokens: StoredTokens): Promise<void> {
+  const dir = resolveDir();
+  const file = resolvePath();
+  await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+  const body = JSON.stringify(tokens, null, 2);
+  await fs.writeFile(file, body, { encoding: 'utf8', mode: 0o600 });
+  try {
+    await fs.chmod(file, 0o600);
+    await fs.chmod(dir, 0o700);
+  } catch {
+    // Windows filesystems may not honor chmod; best-effort only.
+  }
+}
+
+export async function clear(): Promise<void> {
+  const file = resolvePath();
+  try {
+    await fs.unlink(file);
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code !== 'ENOENT') throw err;
+  }
+}
+
+export function location(): string {
+  return resolvePath();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -860,6 +860,274 @@ const TOOLS = [
         pageSize: { type: 'number', description: 'Number of results per page (default: 50)' }
       }
     }
+  },
+  {
+    name: 'query_backup_jobs',
+    description: 'Query backup jobs with optional status/plan filters',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        df: { type: 'string' },
+        cursor: { type: 'string' },
+        pageSize: { type: 'number' },
+        status: { type: 'string', description: 'Optional job status filter (e.g. SUCCESS, FAILED)' },
+        planType: { type: 'string', description: 'Optional backup plan type filter' }
+      }
+    }
+  },
+  {
+    name: 'query_backup_integrity',
+    description: 'Query backup integrity check results',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        df: { type: 'string' },
+        cursor: { type: 'string' },
+        pageSize: { type: 'number' }
+      }
+    }
+  },
+
+  // Auth tools (authorization_code flow)
+  {
+    name: 'ninja_auth_status',
+    description: 'Show active auth mode, token status, tenant base URL, and refresh-token availability',
+    inputSchema: { type: 'object', properties: {} }
+  },
+  {
+    name: 'ninja_auth_login',
+    description: 'Start an authorization_code OAuth login (opens browser via loopback; falls back to manual paste).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        manual: {
+          type: 'boolean',
+          description: 'If true, skip loopback and only return the authorize URL for manual paste.'
+        }
+      }
+    }
+  },
+  {
+    name: 'ninja_auth_paste_redirect',
+    description: 'Complete an in-progress authorization_code login by pasting the full redirect URL (with ?code=&state=).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        url: { type: 'string', description: 'Full redirect URL returned by the NinjaOne authorize endpoint' }
+      },
+      required: ['url']
+    }
+  },
+  {
+    name: 'ninja_auth_logout',
+    description: 'Clear stored access and refresh tokens for the authorization_code flow.',
+    inputSchema: { type: 'object', properties: {} }
+  },
+
+  // Ticketing
+  {
+    name: 'get_tickets',
+    description: 'List tickets using the NinjaOne ticket filter API',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        filter: { type: 'string', description: 'Ticket filter expression' },
+        pageSize: { type: 'number' },
+        cursor: { type: 'string' },
+        sortBy: { type: 'string' }
+      }
+    }
+  },
+  {
+    name: 'get_ticket',
+    description: 'Get a single ticket by ID',
+    inputSchema: { type: 'object', properties: { ticketId: { type: 'number' } }, required: ['ticketId'] }
+  },
+  {
+    name: 'create_ticket',
+    description: 'Create a new ticket. Payload fields depend on tenant ticket form (subject, description, priority, clientId, etc.).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        payload: { type: 'object', description: 'Ticket creation payload as per NinjaOne Ticketing API', additionalProperties: true }
+      },
+      required: ['payload']
+    }
+  },
+  {
+    name: 'update_ticket',
+    description: 'Update an existing ticket',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ticketId: { type: 'number' },
+        payload: { type: 'object', additionalProperties: true }
+      },
+      required: ['ticketId', 'payload']
+    }
+  },
+  {
+    name: 'get_ticket_log_entries',
+    description: 'Retrieve log entries (comments/activity) for a ticket',
+    inputSchema: { type: 'object', properties: { ticketId: { type: 'number' } }, required: ['ticketId'] }
+  },
+  {
+    name: 'add_ticket_log_entry',
+    description: 'Add a log entry (comment/public or internal) to a ticket',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ticketId: { type: 'number' },
+        payload: { type: 'object', additionalProperties: true, description: 'Log entry payload (body, type, publicEntry, etc.)' }
+      },
+      required: ['ticketId', 'payload']
+    }
+  },
+  {
+    name: 'get_ticketing_attributes',
+    description: 'Get ticket attribute metadata (statuses, priorities, custom fields)',
+    inputSchema: { type: 'object', properties: {} }
+  },
+  {
+    name: 'get_ticketing_contacts',
+    description: 'List ticketing contacts',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        pageSize: { type: 'number' },
+        cursor: { type: 'string' },
+        searchCriteria: { type: 'string' }
+      }
+    }
+  },
+
+  // Scripts (authorization_code required)
+  {
+    name: 'get_device_scripting_options',
+    description: 'List scripts/actions available to run on a device (requires authorization_code flow)',
+    inputSchema: { type: 'object', properties: { id: { type: 'number' } }, required: ['id'] }
+  },
+  {
+    name: 'run_device_script',
+    description: 'Run a script on a device (requires authorization_code flow). Payload: { type, uid|id, parameters?, runAs? }.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: { type: 'number' },
+        payload: { type: 'object', additionalProperties: true }
+      },
+      required: ['id', 'payload']
+    }
+  },
+  {
+    name: 'get_job_status',
+    description: 'Get status of a script/job by UID',
+    inputSchema: { type: 'object', properties: { jobUid: { type: 'string' } }, required: ['jobUid'] }
+  },
+
+  // Documentation
+  {
+    name: 'get_document_templates',
+    description: 'List NinjaOne Documentation templates',
+    inputSchema: { type: 'object', properties: {} }
+  },
+  {
+    name: 'get_document_template',
+    description: 'Get a specific documentation template',
+    inputSchema: { type: 'object', properties: { id: { type: 'number' } }, required: ['id'] }
+  },
+  {
+    name: 'create_document_template',
+    description: 'Create a documentation template',
+    inputSchema: {
+      type: 'object',
+      properties: { payload: { type: 'object', additionalProperties: true } },
+      required: ['payload']
+    }
+  },
+  {
+    name: 'update_document_template',
+    description: 'Update a documentation template',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: { type: 'number' },
+        payload: { type: 'object', additionalProperties: true }
+      },
+      required: ['id', 'payload']
+    }
+  },
+  {
+    name: 'get_organization_documents',
+    description: 'List NinjaOne Documentation documents scoped to an organization',
+    inputSchema: { type: 'object', properties: { organizationId: { type: 'number' } }, required: ['organizationId'] }
+  },
+  {
+    name: 'create_organization_document',
+    description: 'Create a documentation document under an organization',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        organizationId: { type: 'number' },
+        payload: { type: 'object', additionalProperties: true }
+      },
+      required: ['organizationId', 'payload']
+    }
+  },
+  {
+    name: 'update_organization_document',
+    description: 'Update a documentation document under an organization',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        organizationId: { type: 'number' },
+        documentId: { type: 'number' },
+        payload: { type: 'object', additionalProperties: true }
+      },
+      required: ['organizationId', 'documentId', 'payload']
+    }
+  },
+
+  // Device custom fields
+  {
+    name: 'get_device_custom_fields',
+    description: 'Retrieve custom field values for a device',
+    inputSchema: { type: 'object', properties: { id: { type: 'number' } }, required: ['id'] }
+  },
+  {
+    name: 'update_device_custom_fields',
+    description: 'Update custom field values for a device (object of { fieldName: value })',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: { type: 'number' },
+        fields: { type: 'object', additionalProperties: true }
+      },
+      required: ['id', 'fields']
+    }
+  },
+
+  // Webhooks
+  {
+    name: 'set_webhook',
+    description: 'Create or update the tenant webhook configuration',
+    inputSchema: {
+      type: 'object',
+      properties: { payload: { type: 'object', additionalProperties: true } },
+      required: ['payload']
+    }
+  },
+  {
+    name: 'delete_webhook',
+    description: 'Remove the tenant webhook configuration',
+    inputSchema: { type: 'object', properties: {} }
+  },
+
+  // Attachments
+  {
+    name: 'get_attachment',
+    description: 'Fetch an attachment by ID. Returns base64-encoded bytes plus content-type and size.',
+    inputSchema: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] }
   }
 ];
 
@@ -876,7 +1144,7 @@ class NinjaOneMCPServer {
       this.server = new Server(
         {
           name: 'ninjaone-mcp-server',
-          version: '1.2.0',
+          version: '1.3.0',
         },
         {
           capabilities: {
@@ -1206,6 +1474,86 @@ class NinjaOneMCPServer {
         return this.api.resetDevicePolicyOverrides(args.id);
       case 'get_policies':
         return this.api.getPolicies(args.templateOnly);
+
+      // Backup (new)
+      case 'query_backup_jobs':
+        return this.api.queryBackupJobs(args.df, args.cursor, args.pageSize, args.status, args.planType);
+      case 'query_backup_integrity':
+        return this.api.queryBackupIntegrityChecks(args.df, args.cursor, args.pageSize);
+
+      // Auth
+      case 'ninja_auth_status':
+        return this.api.getAuthStatus();
+      case 'ninja_auth_login':
+        return this.api.startLogin(args.manual !== true);
+      case 'ninja_auth_paste_redirect': {
+        if (typeof args.url !== 'string' || !args.url) {
+          throw new McpError(ErrorCode.InvalidParams, 'url is required');
+        }
+        await this.api.completeLoginFromRedirect(args.url);
+        return { success: true, message: 'Login completed and tokens stored.' };
+      }
+      case 'ninja_auth_logout':
+        await this.api.logout();
+        return { success: true, message: 'Tokens cleared.' };
+
+      // Ticketing
+      case 'get_tickets':
+        return this.api.getTickets(args.filter, args.pageSize, args.cursor, args.sortBy);
+      case 'get_ticket':
+        return this.api.getTicket(args.ticketId);
+      case 'create_ticket':
+        return this.api.createTicket(args.payload);
+      case 'update_ticket':
+        return this.api.updateTicket(args.ticketId, args.payload);
+      case 'get_ticket_log_entries':
+        return this.api.getTicketLogEntries(args.ticketId);
+      case 'add_ticket_log_entry':
+        return this.api.addTicketLogEntry(args.ticketId, args.payload);
+      case 'get_ticketing_attributes':
+        return this.api.getTicketingAttributes();
+      case 'get_ticketing_contacts':
+        return this.api.getTicketingContacts(args.pageSize, args.cursor, args.searchCriteria);
+
+      // Scripts
+      case 'get_device_scripting_options':
+        return this.api.getDeviceScriptingOptions(args.id);
+      case 'run_device_script':
+        return this.api.runDeviceScript(args.id, args.payload);
+      case 'get_job_status':
+        return this.api.getJobStatus(args.jobUid);
+
+      // Documentation
+      case 'get_document_templates':
+        return this.api.getDocumentTemplates();
+      case 'get_document_template':
+        return this.api.getDocumentTemplate(args.id);
+      case 'create_document_template':
+        return this.api.createDocumentTemplate(args.payload);
+      case 'update_document_template':
+        return this.api.updateDocumentTemplate(args.id, args.payload);
+      case 'get_organization_documents':
+        return this.api.getOrganizationDocuments(args.organizationId);
+      case 'create_organization_document':
+        return this.api.createOrganizationDocument(args.organizationId, args.payload);
+      case 'update_organization_document':
+        return this.api.updateOrganizationDocument(args.organizationId, args.documentId, args.payload);
+
+      // Device custom fields
+      case 'get_device_custom_fields':
+        return this.api.getDeviceCustomFields(args.id);
+      case 'update_device_custom_fields':
+        return this.api.updateDeviceCustomFields(args.id, args.fields);
+
+      // Webhooks
+      case 'set_webhook':
+        return this.api.setWebhook(args.payload);
+      case 'delete_webhook':
+        return this.api.deleteWebhook();
+
+      // Attachments
+      case 'get_attachment':
+        return this.api.getAttachment(args.id);
 
       default:
         throw new McpError(ErrorCode.MethodNotFound, `Unknown tool: ${name}`);

--- a/src/ninja-api.ts
+++ b/src/ninja-api.ts
@@ -1,3 +1,16 @@
+import {
+  buildAuthorizeUrl,
+  createPkcePair,
+  createState,
+  exchangeCode,
+  refresh as refreshAccessToken,
+  parseRedirectUrl,
+  type PkcePair,
+  type TokenResponse,
+} from './auth/authorization-code.js';
+import { openBrowser, waitForCallback } from './auth/loopback.js';
+import * as tokenStore from './auth/token-store.js';
+
 type CreateEndUserPayload = {
   firstName: string;
   lastName: string;
@@ -12,14 +25,51 @@ export type MaintenanceWindowSelection =
   | { permanent: true }
   | { permanent: false; value: number; unit: MaintenanceUnit; seconds: number };
 
+export type AuthMode = 'client_credentials' | 'authorization_code';
+
+interface PendingLogin {
+  pkce: PkcePair;
+  state: string;
+  redirectUri: string;
+  scope: string;
+  baseUrl: string;
+}
+
+export interface AuthStatus {
+  mode: AuthMode;
+  configured: boolean;
+  tenantBaseUrl: string | null;
+  accessTokenValid: boolean;
+  accessTokenExpiresAt: number | null;
+  hasRefreshToken: boolean;
+  pendingLogin: boolean;
+  redirectUri: string | null;
+  scope: string | null;
+  tokenStorePath: string;
+}
+
+export interface LoginStartResult {
+  authorizeUrl: string;
+  redirectUri: string;
+  mode: 'loopback' | 'manual';
+  message: string;
+}
+
 export class NinjaOneAPI {
   private baseUrl: string | null = null;
   private clientId: string;
   private clientSecret: string;
   private accessToken: string | null = null;
   private tokenExpiry: number | null = null;
+  private refreshToken: string | null = null;
   private isConfigured: boolean;
   private baseUrlExplicit: boolean = false;
+  private authMode: AuthMode;
+  private redirectUri: string;
+  private oauthPort: number;
+  private scope: string;
+  private pendingLogin: PendingLogin | null = null;
+  private tokenLoadPromise: Promise<void> | null = null;
 
   private static readonly REGION_MAP: Record<string, string> = {
     us: 'https://app.ninjarmm.com',
@@ -37,6 +87,9 @@ export class NinjaOneAPI {
     'https://oc.ninjarmm.com',
   ];
 
+  private static readonly DEFAULT_CC_SCOPE = 'monitoring management control';
+  private static readonly DEFAULT_AC_SCOPE = 'monitoring management control offline_access';
+
   constructor() {
     const envBase = process.env.NINJA_BASE_URL;
     const envRegion = (process.env.NINJA_REGION || '').toLowerCase();
@@ -45,23 +98,263 @@ export class NinjaOneAPI {
       this.baseUrl = this.normalizeBaseUrl(envBase);
       this.baseUrlExplicit = true;
     } else if (envRegion && NinjaOneAPI.REGION_MAP[envRegion]) {
-      this.baseUrl = NinjaOneAPI.REGION_MAP[envRegion];
+      this.baseUrl = NinjaOneAPI.REGION_MAP[envRegion]!;
       this.baseUrlExplicit = true;
     } else {
       this.baseUrl = null;
     }
     this.clientId = process.env.NINJA_CLIENT_ID || '';
     this.clientSecret = process.env.NINJA_CLIENT_SECRET || '';
-    this.isConfigured = !!(this.clientId && this.clientSecret);
-    
-    if (!this.isConfigured) {
-      console.error('WARNING: NINJA_CLIENT_ID and NINJA_CLIENT_SECRET not set - API calls will fail until configured');
+
+    const modeEnv = (process.env.NINJA_AUTH_MODE || 'client_credentials').toLowerCase();
+    this.authMode = modeEnv === 'authorization_code' ? 'authorization_code' : 'client_credentials';
+
+    const portEnv = parseInt(process.env.NINJA_OAUTH_PORT || '', 10);
+    this.oauthPort = Number.isFinite(portEnv) && portEnv > 0 ? portEnv : 8765;
+    this.redirectUri = process.env.NINJA_OAUTH_REDIRECT_URI
+      || `http://localhost:${this.oauthPort}/callback`;
+    this.scope = process.env.NINJA_OAUTH_SCOPES
+      || (this.authMode === 'authorization_code'
+        ? NinjaOneAPI.DEFAULT_AC_SCOPE
+        : NinjaOneAPI.DEFAULT_CC_SCOPE);
+
+    if (this.authMode === 'authorization_code') {
+      this.isConfigured = !!this.clientId;
+      if (!this.isConfigured) {
+        console.error('WARNING: NINJA_CLIENT_ID not set - authorization_code flow cannot start until configured');
+      } else {
+        console.error(`NinjaONE API initialized (authorization_code flow, redirect=${this.redirectUri})`);
+      }
+      this.tokenLoadPromise = this.loadStoredTokens().catch((err) => {
+        console.error('[ninja-api] token load failed:', err);
+      });
     } else {
-      console.error('NinjaONE API initialized successfully');
+      this.isConfigured = !!(this.clientId && this.clientSecret);
+      if (!this.isConfigured) {
+        console.error('WARNING: NINJA_CLIENT_ID and NINJA_CLIENT_SECRET not set - API calls will fail until configured');
+      } else {
+        console.error('NinjaONE API initialized successfully (client_credentials flow)');
+      }
     }
   }
 
+  public getAuthMode(): AuthMode {
+    return this.authMode;
+  }
+
+  public async getAuthStatus(): Promise<AuthStatus> {
+    await this.ensureTokensLoaded();
+    return {
+      mode: this.authMode,
+      configured: this.isConfigured,
+      tenantBaseUrl: this.baseUrl,
+      accessTokenValid: !!(this.accessToken && this.tokenExpiry && Date.now() < this.tokenExpiry),
+      accessTokenExpiresAt: this.tokenExpiry,
+      hasRefreshToken: !!this.refreshToken,
+      pendingLogin: !!this.pendingLogin,
+      redirectUri: this.authMode === 'authorization_code' ? this.redirectUri : null,
+      scope: this.scope,
+      tokenStorePath: tokenStore.location(),
+    };
+  }
+
+  public async logout(): Promise<void> {
+    this.accessToken = null;
+    this.tokenExpiry = null;
+    this.refreshToken = null;
+    this.pendingLogin = null;
+    await tokenStore.clear();
+  }
+
+  public async startLogin(preferLoopback: boolean = true): Promise<LoginStartResult> {
+    if (this.authMode !== 'authorization_code') {
+      throw new Error('Login is only available when NINJA_AUTH_MODE=authorization_code');
+    }
+    if (!this.clientId) {
+      throw new Error('NINJA_CLIENT_ID is required to start login');
+    }
+
+    const base = await this.resolveBaseUrlForAuth();
+    const pkce = createPkcePair();
+    const state = createState();
+    const authorizeUrl = buildAuthorizeUrl({
+      baseUrl: base,
+      clientId: this.clientId,
+      redirectUri: this.redirectUri,
+      scope: this.scope,
+      state,
+      codeChallenge: pkce.challenge,
+    });
+
+    this.pendingLogin = {
+      pkce,
+      state,
+      redirectUri: this.redirectUri,
+      scope: this.scope,
+      baseUrl: base,
+    };
+
+    if (preferLoopback) {
+      this.runLoopbackFlow(authorizeUrl).catch((err) => {
+        console.error('[ninja-api] loopback login failed:', err);
+      });
+      return {
+        authorizeUrl,
+        redirectUri: this.redirectUri,
+        mode: 'loopback',
+        message: `Open the URL in your browser if it does not launch automatically. After you log in, the flow completes via ${this.redirectUri}. If the loopback cannot receive the callback, call ninja_auth_paste_redirect with the full redirect URL.`,
+      };
+    }
+
+    return {
+      authorizeUrl,
+      redirectUri: this.redirectUri,
+      mode: 'manual',
+      message: `Open the URL in your browser, complete the login, and paste the FULL redirect URL (including ?code=...&state=...) into ninja_auth_paste_redirect.`,
+    };
+  }
+
+  public async completeLoginFromRedirect(redirectUrl: string): Promise<void> {
+    if (!this.pendingLogin) {
+      throw new Error('No pending login — call ninja_auth_login first.');
+    }
+    const parsed = parseRedirectUrl(redirectUrl);
+    if (parsed.error) {
+      throw new Error(`OAuth error from provider: ${parsed.error}`);
+    }
+    if (!parsed.code || !parsed.state) {
+      throw new Error('Redirect URL is missing code or state parameter.');
+    }
+    if (parsed.state !== this.pendingLogin.state) {
+      throw new Error('State mismatch — possible CSRF. Restart the login.');
+    }
+    await this.completeLoginWithCode(parsed.code);
+  }
+
+  private async runLoopbackFlow(authorizeUrl: string): Promise<void> {
+    if (!this.pendingLogin) return;
+    openBrowser(authorizeUrl);
+    try {
+      const result = await waitForCallback({
+        redirectUri: this.pendingLogin.redirectUri,
+        expectedState: this.pendingLogin.state,
+        timeoutMs: 180_000,
+      });
+      await this.completeLoginWithCode(result.code);
+      console.error('[ninja-api] login completed via loopback callback');
+    } catch (err) {
+      console.error('[ninja-api] loopback callback error:', err);
+    }
+  }
+
+  private async completeLoginWithCode(code: string): Promise<void> {
+    if (!this.pendingLogin) {
+      throw new Error('No pending login.');
+    }
+    const pending = this.pendingLogin;
+    const response = await exchangeCode({
+      baseUrl: pending.baseUrl,
+      code,
+      codeVerifier: pending.pkce.verifier,
+      redirectUri: pending.redirectUri,
+      clientId: this.clientId,
+      ...(this.clientSecret ? { clientSecret: this.clientSecret } : {}),
+    });
+    this.baseUrl = pending.baseUrl;
+    this.baseUrlExplicit = true;
+    this.applyTokenResponse(response);
+    await this.persistTokens();
+    this.pendingLogin = null;
+  }
+
+  private async ensureTokensLoaded(): Promise<void> {
+    if (this.tokenLoadPromise) {
+      await this.tokenLoadPromise;
+      this.tokenLoadPromise = null;
+    }
+  }
+
+  private async loadStoredTokens(): Promise<void> {
+    const stored = await tokenStore.load();
+    if (!stored) return;
+    if (stored.tenantBaseUrl && !this.baseUrlExplicit) {
+      this.baseUrl = stored.tenantBaseUrl;
+      this.baseUrlExplicit = true;
+    }
+    this.refreshToken = stored.refreshToken;
+    this.accessToken = stored.accessToken;
+    this.tokenExpiry = stored.expiresAt;
+    if (stored.scope) this.scope = stored.scope;
+  }
+
+  private async persistTokens(): Promise<void> {
+    if (this.authMode !== 'authorization_code') return;
+    await tokenStore.save({
+      refreshToken: this.refreshToken,
+      accessToken: this.accessToken,
+      expiresAt: this.tokenExpiry,
+      tenantBaseUrl: this.baseUrl,
+      scope: this.scope,
+      clientId: this.clientId || null,
+    });
+  }
+
+  private applyTokenResponse(token: TokenResponse): void {
+    this.accessToken = token.access_token;
+    this.tokenExpiry = Date.now() + (token.expires_in * 1000);
+    if (token.refresh_token) {
+      this.refreshToken = token.refresh_token;
+    }
+    if (token.scope) {
+      this.scope = token.scope;
+    }
+  }
+
+  private async resolveBaseUrlForAuth(): Promise<string> {
+    if (this.baseUrl) return this.baseUrl;
+    const candidates = this.getCandidateBaseUrls();
+    const first = candidates[0];
+    if (!first) throw new Error('No candidate base URL available');
+    this.baseUrl = first;
+    return first;
+  }
+
   private async getAccessToken(): Promise<string> {
+    await this.ensureTokensLoaded();
+
+    if (this.authMode === 'authorization_code') {
+      return this.getAccessTokenAuthorizationCode();
+    }
+    return this.getAccessTokenClientCredentials();
+  }
+
+  private async getAccessTokenAuthorizationCode(): Promise<string> {
+    if (!this.clientId) {
+      throw new Error('NinjaONE API not configured - NINJA_CLIENT_ID required');
+    }
+
+    if (this.accessToken && this.tokenExpiry && Date.now() < (this.tokenExpiry - 300_000)) {
+      return this.accessToken;
+    }
+
+    if (!this.refreshToken) {
+      throw new Error('Not logged in. Call ninja_auth_login to authorize via browser.');
+    }
+
+    const base = await this.resolveBaseUrlForAuth();
+    const response = await refreshAccessToken({
+      baseUrl: base,
+      refreshToken: this.refreshToken,
+      clientId: this.clientId,
+      ...(this.clientSecret ? { clientSecret: this.clientSecret } : {}),
+      scope: this.scope,
+    });
+    this.applyTokenResponse(response);
+    await this.persistTokens();
+    return this.accessToken!;
+  }
+
+  private async getAccessTokenClientCredentials(): Promise<string> {
     if (!this.isConfigured) {
       throw new Error('NinjaONE API not configured - NINJA_CLIENT_ID and NINJA_CLIENT_SECRET required');
     }
@@ -97,13 +390,22 @@ export class NinjaOneAPI {
     return this.accessToken!;
   }
 
+  public requireAuthorizationCodeMode(operation: string): void {
+    if (this.authMode !== 'authorization_code') {
+      throw new Error(
+        `${operation} requires authorization_code auth flow. ` +
+        `Set NINJA_AUTH_MODE=authorization_code and run ninja_auth_login.`
+      );
+    }
+  }
+
   private async requestToken(baseUrl: string): Promise<{ access_token: string; expires_in: number }> {
     const tokenUrl = `${baseUrl}/ws/oauth/token`;
     const body = new URLSearchParams({
       grant_type: 'client_credentials',
       client_id: this.clientId,
       client_secret: this.clientSecret,
-      scope: 'monitoring management control'
+      scope: this.scope || NinjaOneAPI.DEFAULT_CC_SCOPE,
     });
 
     const response = await fetch(tokenUrl, {
@@ -198,6 +500,12 @@ export class NinjaOneAPI {
     this.baseUrlExplicit = true;
     this.accessToken = null;
     this.tokenExpiry = null;
+    if (this.authMode === 'authorization_code') {
+      // Refresh tokens are tenant-bound; re-login required after switching tenant.
+      this.refreshToken = null;
+      this.pendingLogin = null;
+      void this.persistTokens();
+    }
   }
 
   private buildQuery(params: Record<string, any>): string {
@@ -657,5 +965,143 @@ export class NinjaOneAPI {
    */
   async getDeviceSoftware(id: number): Promise<any> {
     return this.makeRequest(`/v2/device/${id}/software`);
+  }
+
+  // Ticketing
+
+  async getTickets(filter?: string, pageSize?: number, cursor?: string, sortBy?: string): Promise<any> {
+    return this.makeRequest(`/v2/ticketing/trigger/tickets${this.buildQuery({ filter, pageSize, cursor, sortBy })}`);
+  }
+
+  async getTicket(ticketId: number): Promise<any> {
+    return this.makeRequest(`/v2/ticketing/ticket/${ticketId}`);
+  }
+
+  async createTicket(payload: Record<string, unknown>): Promise<any> {
+    return this.makeRequest('/v2/ticketing/ticket', 'POST', payload);
+  }
+
+  async updateTicket(ticketId: number, payload: Record<string, unknown>): Promise<any> {
+    return this.makeRequest(`/v2/ticketing/ticket/${ticketId}`, 'PUT', payload);
+  }
+
+  async getTicketLogEntries(ticketId: number): Promise<any> {
+    return this.makeRequest(`/v2/ticketing/ticket/${ticketId}/log-entry`);
+  }
+
+  async addTicketLogEntry(ticketId: number, payload: Record<string, unknown>): Promise<any> {
+    return this.makeRequest(`/v2/ticketing/ticket/${ticketId}/log-entry`, 'POST', payload);
+  }
+
+  async getTicketingAttributes(): Promise<any> {
+    return this.makeRequest('/v2/ticketing/attributes');
+  }
+
+  async getTicketingContacts(pageSize?: number, cursor?: string, searchCriteria?: string): Promise<any> {
+    return this.makeRequest(`/v2/ticketing/contact/contacts${this.buildQuery({ pageSize, cursor, searchCriteria })}`);
+  }
+
+  // Scripts (authorization_code required)
+
+  async getDeviceScriptingOptions(id: number): Promise<any> {
+    this.requireAuthorizationCodeMode('run_device_script / get_device_scripting_options');
+    return this.makeRequest(`/v2/device/${id}/scripting/options`);
+  }
+
+  async runDeviceScript(id: number, payload: Record<string, unknown>): Promise<any> {
+    this.requireAuthorizationCodeMode('run_device_script');
+    return this.makeRequest(`/v2/device/${id}/script/run`, 'POST', payload);
+  }
+
+  async getJobStatus(jobUid: string): Promise<any> {
+    return this.makeRequest(`/v2/job/${encodeURIComponent(jobUid)}`);
+  }
+
+  // NinjaOne Documentation
+
+  async getDocumentTemplates(): Promise<any> {
+    return this.makeRequest('/v2/document-templates');
+  }
+
+  async getDocumentTemplate(id: number): Promise<any> {
+    return this.makeRequest(`/v2/document-template/${id}`);
+  }
+
+  async createDocumentTemplate(payload: Record<string, unknown>): Promise<any> {
+    return this.makeRequest('/v2/document-templates', 'POST', payload);
+  }
+
+  async updateDocumentTemplate(id: number, payload: Record<string, unknown>): Promise<any> {
+    return this.makeRequest(`/v2/document-template/${id}`, 'PATCH', payload);
+  }
+
+  async getOrganizationDocuments(organizationId: number): Promise<any> {
+    return this.makeRequest(`/v2/organization/${organizationId}/documents`);
+  }
+
+  async createOrganizationDocument(organizationId: number, payload: Record<string, unknown>): Promise<any> {
+    return this.makeRequest(`/v2/organization/${organizationId}/documents`, 'POST', payload);
+  }
+
+  async updateOrganizationDocument(
+    organizationId: number,
+    documentId: number,
+    payload: Record<string, unknown>
+  ): Promise<any> {
+    return this.makeRequest(`/v2/organization/${organizationId}/document/${documentId}`, 'PATCH', payload);
+  }
+
+  // Custom fields per device
+
+  async getDeviceCustomFields(id: number): Promise<any> {
+    return this.makeRequest(`/v2/device/${id}/custom-fields`);
+  }
+
+  async updateDeviceCustomFields(id: number, fields: Record<string, unknown>): Promise<any> {
+    return this.makeRequest(`/v2/device/${id}/custom-fields`, 'PATCH', fields);
+  }
+
+  // Webhooks
+
+  async setWebhook(payload: Record<string, unknown>): Promise<any> {
+    return this.makeRequest('/v2/webhook', 'PUT', payload);
+  }
+
+  async deleteWebhook(): Promise<any> {
+    return this.makeRequest('/v2/webhook', 'DELETE');
+  }
+
+  // Attachments (binary)
+
+  async getAttachment(id: string): Promise<{ contentType: string; base64: string; size: number }> {
+    const token = await this.getAccessToken();
+    const base = this.baseUrl || NinjaOneAPI.DEFAULT_CANDIDATES[0]!;
+    const response = await fetch(`${base}/v2/attachment/${encodeURIComponent(id)}`, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Accept': '*/*',
+      },
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`API request failed: ${response.status} ${response.statusText} - ${text}`);
+    }
+    const buf = Buffer.from(await response.arrayBuffer());
+    return {
+      contentType: response.headers.get('content-type') || 'application/octet-stream',
+      base64: buf.toString('base64'),
+      size: buf.byteLength,
+    };
+  }
+
+  // Backup
+
+  async queryBackupJobs(df?: string, cursor?: string, pageSize?: number, status?: string, planType?: string): Promise<any> {
+    return this.makeRequest(`/v2/queries/backup/jobs${this.buildQuery({ df, cursor, pageSize, status, planType })}`);
+  }
+
+  async queryBackupIntegrityChecks(df?: string, cursor?: string, pageSize?: number): Promise<any> {
+    return this.makeRequest(`/v2/queries/backup/integrity${this.buildQuery({ df, cursor, pageSize })}`);
   }
 }


### PR DESCRIPTION
## Summary
This PR adds comprehensive OAuth2 authorization_code flow support alongside the existing client_credentials flow, enabling user-context operations like script execution. It also introduces new API endpoints for ticketing, documentation, device custom fields, webhooks, and backup operations.

## Key Changes

### Authentication & Authorization
- **Dual OAuth2 flows**: Added `NINJA_AUTH_MODE` environment variable to switch between `client_credentials` (default, service-to-service) and `authorization_code` (user-context with browser login)
- **Authorization code implementation** (`src/auth/authorization-code.ts`):
  - PKCE (S256) support for secure code exchange
  - State parameter generation for CSRF protection
  - Token refresh mechanism with automatic expiry handling
- **Loopback server** (`src/auth/loopback.ts`):
  - Local HTTP server on configurable port (default 8765) to receive OAuth callbacks
  - Automatic browser opening on supported platforms (macOS, Windows, Linux)
  - Fallback to manual redirect URL pasting for headless environments
- **Token persistence** (`src/auth/token-store.ts`):
  - Secure file-based storage at `~/.ninjaone-mcp/tokens.json` (mode 0600)
  - Automatic token loading on initialization
  - Support for custom token directory via `NINJA_TOKEN_DIR`

### New API Endpoints
- **Ticketing**: `get_tickets`, `get_ticket`, `create_ticket`, `update_ticket`, `get_ticket_log_entries`, `add_ticket_log_entry`, `get_ticketing_attributes`, `get_ticketing_contacts`
- **Scripts** (authorization_code required): `get_device_scripting_options`, `run_device_script`, `get_job_status`
- **Documentation**: `get_document_templates`, `get_document_template`, `create_document_template`, `update_document_template`, `get_organization_documents`, `create_organization_document`, `update_organization_document`
- **Device custom fields**: `get_device_custom_fields`, `update_device_custom_fields`
- **Webhooks**: `set_webhook`, `delete_webhook`
- **Attachments**: `get_attachment`
- **Backup**: `query_backup_jobs`, `query_backup_integrity`

### Authentication Management Tools
- `ninja_auth_status` — inspect auth mode, token validity, refresh-token availability, and tenant base URL
- `ninja_auth_login` — initiate browser-based login with optional loopback or manual mode
- `ninja_auth_paste_redirect` — complete login by pasting the full redirect URL
- `ninja_auth_logout` — clear stored tokens

### Implementation Details
- Token refresh is automatic and transparent; access tokens are refreshed 5 minutes before expiry
- Tenant base URL is persisted with tokens and restored on subsequent loads
- Script execution endpoints enforce authorization_code mode via `requireAuthorizationCodeMode()`
- Scope defaults: `monitoring management control` for client_credentials, `monitoring management control offline_access` for authorization_code
- All token operations are async and properly awaited during initialization
- Environment variables support: `NINJA_AUTH_MODE`, `NINJA_OAUTH_REDIRECT_URI`, `NINJA_OAUTH_PORT`, `NINJA_OAUTH_SCOPES`, `NINJA_TOKEN_DIR`

### Documentation Updates
- Updated README with authentication flow explanations and configuration examples
- Added SETUP.md section for authorization_code flow setup
- Updated TOOLS.md with new endpoint categories
- Updated manifest.json with new configuration options and version bump to 1.3.0

### Version Bump
- Updated package.json and manifest.json to version 1.3.0
- Updated MCP server version constant to 1.3.0